### PR TITLE
Force Discord avatars to be PNGs

### DIFF
--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -500,13 +500,13 @@ export class MatrixEventProcessor {
             if (userOrMember instanceof Discord.User) {
                 embed.setAuthor(
                     userOrMember.username,
-                    userOrMember.avatarURL() || undefined,
+                    userOrMember.avatarURL({ format: 'png' }) || undefined,
                 );
                 return;
             } else if (userOrMember instanceof Discord.GuildMember) {
                 embed.setAuthor(
                     userOrMember.displayName,
-                    userOrMember.user.avatarURL() || undefined,
+                    userOrMember.user.avatarURL({ format: 'png' }) || undefined,
                 );
                 return;
             }

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -257,7 +257,7 @@ export class UserSyncroniser {
             userState.createUser = true;
             userState.displayName = displayName;
             if (discordUser.avatar) {
-                userState.avatarUrl = discordUser.avatarURL();
+                userState.avatarUrl = discordUser.avatarURL({ format: 'png' });
                 userState.avatarId = discordUser.avatar;
             }
             return userState;
@@ -270,10 +270,10 @@ export class UserSyncroniser {
         }
 
         const oldAvatarUrl = remoteUser.avatarurl;
-        if (oldAvatarUrl !== discordUser.avatarURL()) {
+        if (oldAvatarUrl !== discordUser.avatarURL({ format: 'png' })) {
             log.verbose(`User ${discordUser.id} avatarurl should be updated`);
             if (discordUser.avatar) {
-                userState.avatarUrl = discordUser.avatarURL();
+                userState.avatarUrl = discordUser.avatarURL({ format: 'png' });
                 userState.avatarId = discordUser.avatar;
             } else {
                 userState.removeAvatar = true;


### PR DESCRIPTION
This PR tries to force all discord avatars to be be fetched via PNGs instead of WEBPs in order to hopefully fix https://github.com/matrix-org/matrix-appservice-discord/issues/788

I cannot compile the project nor run the bot locally, so I cannot tell if this breaks anything.

Depending on the result of this, I'll PR this later to upstream as well.