### PR TITLE
Remove annoying popup when linking to earlier discord message.

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -567,7 +567,7 @@ export class DiscordBot {
                 return;
             }
             const link = `https://discord.com/channels/${chan.guild.id}/${chan.id}/${editEventId}`;
-            embedSet.messageEmbed.description = `[Edit](${link}): ${embedSet.messageEmbed.description}`;
+            embedSet.messageEmbed.description = `[Edit](<${link}>): ${embedSet.messageEmbed.description}`;
             await this.send(embedSet, opts, roomLookup, event);
         } catch (err) {
             // throw wrapError(err, Unstable.ForeignNetworkError, "Couldn't edit message");


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->

# What does this commit do?
It removes the embed under a message when a editing message is send.
Example:
It removes this embed
![image](https://github.com/t2bot/matrix-appservice-discord/assets/69577313/ebf6000d-ea8a-4d13-a83e-1f99b1b19570)

